### PR TITLE
lets move to skaffold

### DIFF
--- a/packs/csharp/.dockerignore
+++ b/packs/csharp/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE

--- a/packs/go/.dockerignore
+++ b/packs/go/.dockerignore
@@ -1,5 +1,12 @@
-Dockerfile
 draft.toml
+target/classes
+target/generated-sources
+target/generated-test-sources
+target/maven-archiver
+target/maven-status
+target/surefire-reports
+target/test-classes
+target/*.original
 charts/
 NOTICE
 LICENSE

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
                 sh "git checkout master"
                 // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
                 sh "git config --global credential.helper store"
-                sh "jx step validate --min-jx-version 1.1.72"
+                sh "jx step validate --min-jx-version 1.1.73"
                 sh "jx step git credentials"
 
                 sh "make tag"

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -23,8 +23,7 @@ pipeline {
             checkout scm
             container('go') {
               sh "make linux"
-              sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-              sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+              sh 'export VERSION=$PREVIEW_VERSION && skaffold run -f skaffold.yaml'
             }
           }
           dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview') {
@@ -59,8 +58,7 @@ pipeline {
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME') {
               container('go') {
                 sh "make build"
-                sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION) ."
-                sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+                sh 'export VERSION=`cat VERSION` && skaffold run -f skaffold.yaml'
               }
             }
           }

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
                 sh "git checkout master"
                 // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
                 sh "git config --global credential.helper store"
-                sh "jx step validate --min-jx-version 1.1.71"
+                sh "jx step validate --min-jx-version 1.1.72"
                 sh "jx step git credentials"
 
                 sh "make tag"

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -6,10 +6,7 @@ pipeline {
       ORG               = 'REPLACE_ME_ORG'
       APP_NAME          = 'REPLACE_ME_APP_NAME'
       GIT_PROVIDER      = 'REPLACE_ME_GIT_PROVIDER'
-      GIT_CREDS         = credentials('jenkins-x-git')
       CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-      GIT_USERNAME      = "$GIT_CREDS_USR"
-      GIT_API_TOKEN     = "$GIT_CREDS_PSW"
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -54,6 +51,8 @@ pipeline {
                 sh "git checkout master"
                 // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
                 sh "git config --global credential.helper store"
+                sh "jx step validate --min-jx-version 1.1.71"
+                sh "jx step git credentials"
 
                 sh "make tag"
             }

--- a/packs/go/skaffold.yaml
+++ b/packs/go/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/{{.ORG}}/{{.APP_NAME}}:{{.VERSION}}"
+  artifacts:
+  - imageName: changeme
+    workspace: .
+    docker: {}
+  local: {}
+deploy:
+  kubectl:
+    manifests:

--- a/packs/gradle/.dockerignore
+++ b/packs/gradle/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -5,10 +5,7 @@ pipeline {
     environment {
       ORG               = 'jenkinsx'
       APP_NAME          = 'REPLACE_ME_APP_NAME'
-      GIT_CREDS         = credentials('jenkins-x-git')
       CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-      GIT_USERNAME      = "$GIT_CREDS_USR"
-      GIT_API_TOKEN     = "$GIT_CREDS_PSW"
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -45,8 +42,9 @@ pipeline {
           container('gradle') {
             // ensure we're not on a detached head
             sh "git checkout master"
-            // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
+            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"
             // TODO

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.72"
+            sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step validate --min-jx-version 1.1.72"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -22,8 +22,7 @@ pipeline {
             // TODO 
             //sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
             sh "gradle clean build"
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh 'export VERSION=$PREVIEW_VERSION && skaffold run -f skaffold.yaml'
           }
 
           dir ('./charts/preview') {
@@ -58,8 +57,7 @@ pipeline {
           container('gradle') {
             sh 'gradle clean build'
 
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION) ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh 'export VERSION=`cat VERSION` && skaffold run -f skaffold.yaml'
           }
         }
       }

--- a/packs/gradle/skaffold.yaml
+++ b/packs/gradle/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/{{.ORG}}/{{.APP_NAME}}:{{.VERSION}}"
+  artifacts:
+  - imageName: changeme
+    workspace: .
+    docker: {}
+  local: {}
+deploy:
+  kubectl:
+    manifests:

--- a/packs/javascript/.dockerignore
+++ b/packs/javascript/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.72"
+            sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -42,7 +42,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step validate --min-jx-version 1.1.72"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -5,10 +5,7 @@ pipeline {
     environment {
       ORG               = 'jenkinsx'
       APP_NAME          = 'REPLACE_ME_APP_NAME'
-      GIT_CREDS         = credentials('jenkins-x-git')
       CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-      GIT_USERNAME      = "$GIT_CREDS_USR"
-      GIT_API_TOKEN     = "$GIT_CREDS_PSW"
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -45,8 +42,9 @@ pipeline {
           container('nodejs') {
             // ensure we're not on a detached head
             sh "git checkout master"
-            // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
+            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"
           }

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -22,8 +22,7 @@ pipeline {
             sh "npm install"
             sh "npm test"
 
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh 'export VERSION=$PREVIEW_VERSION && skaffold run -f skaffold.yaml'
           }
 
           dir ('./charts/preview') {
@@ -57,8 +56,7 @@ pipeline {
             sh "npm install"
             sh "npm test"
 
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION) ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh 'export VERSION=`cat VERSION` && skaffold run -f skaffold.yaml'
           }
         }
       }

--- a/packs/javascript/skaffold.yaml
+++ b/packs/javascript/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/{{.ORG}}/{{.APP_NAME}}:{{.VERSION}}"
+  artifacts:
+  - imageName: changeme
+    workspace: .
+    docker: {}
+  local: {}
+deploy:
+  kubectl:
+    manifests:

--- a/packs/maven/.dockerignore
+++ b/packs/maven/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -86,7 +86,7 @@ pipeline {
             input """Pipeline failed. 
 We will keep the build pod around to help you diagnose any failures. 
 
-Press OK to terminate the pipeline"""
+Select Proceed or Abort to terminate the build pod"""
         }
     }
   }

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -5,10 +5,7 @@ pipeline {
     environment {
       ORG               = 'jenkinsx'
       APP_NAME          = 'REPLACE_ME_APP_NAME'
-      GIT_CREDS         = credentials('jenkins-x-git')
       CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-      GIT_USERNAME      = "$GIT_CREDS_USR"
-      GIT_API_TOKEN     = "$GIT_CREDS_PSW"
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -44,8 +41,9 @@ pipeline {
           container('maven') {
             // ensure we're not on a detached head
             sh "git checkout master"
-            // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
+            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.72"
+            sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -82,5 +82,11 @@ pipeline {
         always {
             cleanWs()
         }
+        failure {
+            input """Pipeline failed. 
+We will keep the build pod around to help you diagnose any failures. 
+
+Press OK to terminate the pipeline"""
+        }
     }
   }

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -41,7 +41,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step validate --min-jx-version 1.1.72"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -21,8 +21,7 @@ pipeline {
           container('maven') {
             sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
             sh "mvn install"
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh 'export VERSION=$PREVIEW_VERSION && skaffold run -f skaffold.yaml'
           }
 
           dir ('./charts/preview') {
@@ -56,8 +55,7 @@ pipeline {
           container('maven') {
             sh 'mvn clean deploy'
 
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION) ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh 'export VERSION=`cat VERSION` && skaffold run -f skaffold.yaml'
           }
         }
       }

--- a/packs/maven/skaffold.yaml
+++ b/packs/maven/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/{{.ORG}}/{{.APP_NAME}}:{{.VERSION}}"
+  artifacts:
+  - imageName: changeme
+    workspace: .
+    docker: {}
+  local: {}
+deploy:
+  kubectl:
+    manifests:

--- a/packs/php/.dockerignore
+++ b/packs/php/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE

--- a/packs/python/.dockerignore
+++ b/packs/python/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE

--- a/packs/ruby/.dockerignore
+++ b/packs/ruby/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE

--- a/packs/rust/.dockerignore
+++ b/packs/rust/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 Cargo.toml
 charts/
 NOTICE

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -24,8 +24,7 @@ pipeline {
             sh "cargo install"
             sh "cp ~/.cargo/bin/REPLACE_ME_APP_NAME ."
 
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh 'export VERSION=$PREVIEW_VERSION && skaffold run -f skaffold.yaml'
           }
 
           dir ('./charts/preview') {
@@ -61,8 +60,7 @@ pipeline {
             sh "cargo install"
             sh "cp ~/.cargo/bin/REPLACE_ME_APP_NAME ."
 
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION) ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh 'export VERSION=`cat VERSION` && skaffold run -f skaffold.yaml'
           }
         }
       }

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -5,10 +5,7 @@ pipeline {
     environment {
       ORG               = 'jenkinsx'
       APP_NAME          = 'REPLACE_ME_APP_NAME'
-      GIT_CREDS         = credentials('jenkins-x-git')
       CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-      GIT_USERNAME      = "$GIT_CREDS_USR"
-      GIT_API_TOKEN     = "$GIT_CREDS_PSW"
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -47,8 +44,9 @@ pipeline {
           container('rust') {
             // ensure we're not on a detached head
             sh "git checkout master"
-            // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
+            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"
           }

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.71"
+            sh "jx step validate --min-jx-version 1.1.72"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
             // ensure we're not on a detached head
             sh "git checkout master"
             sh "git config --global credential.helper store"
-            sh "jx step validate --min-jx-version 1.1.72"
+            sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
             sh "echo \$(jx-release-version) > VERSION"

--- a/packs/rust/skaffold.yaml
+++ b/packs/rust/skaffold.yaml
@@ -1,0 +1,14 @@
+apiVersion: skaffold/v1alpha2
+kind: Config
+build:
+  tagPolicy:
+    envTemplate:
+      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/{{.ORG}}/{{.APP_NAME}}:{{.VERSION}}"
+  artifacts:
+  - imageName: changeme
+    workspace: .
+    docker: {}
+  local: {}
+deploy:
+  kubectl:
+    manifests:

--- a/packs/swift/.dockerignore
+++ b/packs/swift/.dockerignore
@@ -1,4 +1,3 @@
-Dockerfile
 draft.toml
 charts/
 NOTICE


### PR DESCRIPTION
* use the generation of git credentials instead of the `jenkins-git-credentials` secret
* move to skaffold for docker image creation
* avoid hard coded `jenkins-x-git` credential so we can more easily support different git servers