### PR TITLE
Python draft pack - Added Makefile/Fixed container name in last stage/Helm chart fix

### DIFF
--- a/packs/python/Jenkinsfile
+++ b/packs/python/Jenkinsfile
@@ -69,7 +69,7 @@ pipeline {
         }
         steps {
           dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('nodejs') {
+            container('python') {
               sh 'jx step changelog --version v\$(cat ../../VERSION)'
 
               // release the helm chart

--- a/packs/python/charts/Makefile
+++ b/packs/python/charts/Makefile
@@ -1,0 +1,48 @@
+CHART_REPO := http://jenkins-x-chartmuseum:8080
+CURRENT=$(pwd)
+NAME := REPLACE_ME_APP_NAME
+OS := $(shell uname)
+RELEASE_VERSION := $(shell cat ../../VERSION)
+
+build: clean
+	rm -rf requirements.lock
+	helm dependency build
+	helm lint
+
+install: clean build
+	helm install . --name ${NAME}
+
+upgrade: clean build
+	helm upgrade ${NAME} .
+
+delete:
+	helm delete --purge ${NAME}
+
+clean:
+	rm -rf charts
+	rm -rf ${NAME}*.tgz
+
+release: clean
+	helm dependency build
+	helm lint
+	helm init --client-only
+	helm package .
+	curl --fail -u $(CHARTMUSEUM_CREDS_USR):$(CHARTMUSEUM_CREDS_PSW) --data-binary "@$(NAME)-$(shell sed -n 's/^version: //p' Chart.yaml).tgz" $(CHART_REPO)/api/charts
+	rm -rf ${NAME}*.tgz%
+
+tag:
+ifeq ($(OS),Darwin)
+	sed -i "" -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+else ifeq ($(OS),Linux)
+	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
+	sed -i -e "s/repository: .*/repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME/" values.yaml
+	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
+else
+	echo "platfrom $(OS) not supported to release from"
+	exit -1
+endif
+	git add --all
+	git commit -m "release $(RELEASE_VERSION)" --allow-empty # if first release then no verion update is performed
+	git tag -fa v$(RELEASE_VERSION) -m "Release version $(RELEASE_VERSION)"
+	git push origin v$(RELEASE_VERSION)

--- a/packs/python/charts/templates/service.yaml
+++ b/packs/python/charts/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.annotations }}
+  annotations:
+{{ toYaml .Values.service.annotations | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/packs/python/charts/values.yaml
+++ b/packs/python/charts/values.yaml
@@ -1,14 +1,18 @@
 # Default values for python.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-replicaCount: 2
+replicaCount: 1
 image:
+  repository: draft
+  tag: dev
   pullPolicy: IfNotPresent
 service:
-  name: python
+  name: REPLACE_ME_APP_NAME
   type: ClusterIP
   externalPort: 80
   internalPort: 8080
+  annotations:
+    fabric8.io/expose: "true"
 resources:
   limits:
     cpu: 100m
@@ -16,3 +20,5 @@ resources:
   requests:
     cpu: 100m
     memory: 128Mi
+ingress:
+  enabled: false


### PR DESCRIPTION
No Makefile is present for python, therefore was failing on `make tag`:
```[python-http] Running shell script

+ make tag

make: *** No rule to make target `tag'.  Stop.

script returned exit code 2
```

Also fixed the container name in the last stage of Jenkinsfile, as it was failing:

```[python-http] Running shell script

container [nodejs] does not exist in pod [python-xxx]
```

In addition, the helm chart needed to be configured to set a value for the ingress, expose, and image repo. 

