### PR TITLE
fix: running javascript tests in CI mode

### DIFF
--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
         steps {
           container('nodejs') {
             sh "npm install"
-            sh "DISPLAY=:99 npm test"
+            sh "CI=true DISPLAY=:99 npm test"
 
             sh 'export VERSION=$PREVIEW_VERSION && skaffold run -f skaffold.yaml'
 


### PR DESCRIPTION
Test runners like ```Jest``` (and others) by default execute in interactive mode (which enables us to restart, filter tests), so for running in CI we need to set environment variable ```CI=true```