### PR TITLE
make service name for discovery configurable from values

### DIFF
--- a/packs/appserver/charts/templates/service.yaml
+++ b/packs/appserver/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/appserver/charts/templates/service.yaml
+++ b/packs/appserver/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/csharp/charts/templates/service.yaml
+++ b/packs/csharp/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/packs/csharp/charts/templates/service.yaml
+++ b/packs/csharp/charts/templates/service.yaml
@@ -14,6 +14,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/csharp/charts/values.yaml
+++ b/packs/csharp/charts/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 2
 image:
   pullPolicy: IfNotPresent
 service:
-  name: dotnetcore
+  name: REPLACE_ME_APP_NAME
   type: ClusterIP
   externalPort: 8080
   internalPort: 80

--- a/packs/go/charts/templates/service.yaml
+++ b/packs/go/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/go/charts/templates/service.yaml
+++ b/packs/go/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/gradle/charts/templates/service.yaml
+++ b/packs/gradle/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/gradle/charts/templates/service.yaml
+++ b/packs/gradle/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/javascript/charts/templates/service.yaml
+++ b/packs/javascript/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/javascript/charts/templates/service.yaml
+++ b/packs/javascript/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/liberty/charts/templates/service.yaml
+++ b/packs/liberty/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/liberty/charts/templates/service.yaml
+++ b/packs/liberty/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/maven/charts/templates/service.yaml
+++ b/packs/maven/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/maven/charts/templates/service.yaml
+++ b/packs/maven/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/php/charts/templates/service.yaml
+++ b/packs/php/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/packs/php/charts/templates/service.yaml
+++ b/packs/php/charts/templates/service.yaml
@@ -14,6 +14,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/php/charts/values.yaml
+++ b/packs/php/charts/values.yaml
@@ -5,7 +5,7 @@ replicaCount: 2
 image:
   pullPolicy: IfNotPresent
 service:
-  name: php
+  name: REPLACE_ME_APP_NAME
   type: ClusterIP
   externalPort: 80
   internalPort: 80

--- a/packs/python/charts/templates/service.yaml
+++ b/packs/python/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/python/charts/templates/service.yaml
+++ b/packs/python/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/ruby/charts/templates/service.yaml
+++ b/packs/ruby/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/ruby/charts/templates/service.yaml
+++ b/packs/ruby/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/ruby/charts/values.yaml
+++ b/packs/ruby/charts/values.yaml
@@ -7,7 +7,7 @@ image:
   tag: dev
   pullPolicy: IfNotPresent
 service:
-  name: ruby
+  name: REPLACE_ME_APP_NAME
   type: ClusterIP
   externalPort: 80
   internalPort: 3000

--- a/packs/rust/charts/templates/service.yaml
+++ b/packs/rust/charts/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 {{- if .Values.service.annotations }}

--- a/packs/rust/charts/templates/service.yaml
+++ b/packs/rust/charts/templates/service.yaml
@@ -18,6 +18,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/swift/chart/templates/service.yaml
+++ b/packs/swift/chart/templates/service.yaml
@@ -1,7 +1,11 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: REPLACE_ME_APP_NAME
+{{- if .Values.service.name }}
+  name: {{ .Values.service.name }}
+{{- else }}
+  name: {{ template "fullname" . }}
+{{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:

--- a/packs/swift/chart/templates/service.yaml
+++ b/packs/swift/chart/templates/service.yaml
@@ -14,6 +14,6 @@ spec:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
     protocol: TCP
-    name: {{ .Values.service.name }}
+    name: http
   selector:
     app: {{ template "fullname" . }}

--- a/packs/swift/chart/values.yaml
+++ b/packs/swift/chart/values.yaml
@@ -7,7 +7,7 @@ image:
   tag: latest
   pullPolicy: IfNotPresent
 service:
-  name: swift
+  name: REPLACE_ME_APP_NAME
   type: ClusterIP
   externalPort: 80
   internalPort: 8080


### PR DESCRIPTION
Suggesting this as a refinement on https://github.com/jenkins-x/draft-packs/pull/36/ as it makes it clear that the service name is defaulted to the app name and this can be easily switched through the values. I would prefer if the JX defaults were a bit more consistent with the [helm convention](https://github.com/kubernetes/charts/search?q=kind%3A+Service+filename%3Aservice.yaml&unscoped_q=kind%3A+Service+filename%3Aservice) as I'm keen to have my JX charts and packaged/distributed helm charts as close as possible. And the helm convention has good reason behind it as the name needs to be unique when deploying the chart more than once in a namespace.

I've appropriated the existing service.name. In some cases it was a value like 'php' which I'm assuming was just a slip. The service.name value was being used to name a service port. But with the protocol fixed to TCP. My reasoning is that if the protocol is fixed then the name might as well be fixed too like in https://github.com/kubernetes/charts/blob/494a6bc4bc390c7efc070a13a11b3d21acee9f62/stable/centrifugo/templates/service.yaml I'm guessing this is harmless as I can't think of anything that JX could be using that port name for (but please correct me if I'm wrong).