### PR TITLE
Pass GITHUB_AUTH_TOKEN into jx-release-version

### DIFF
--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {

--- a/packs/csharp/Jenkinsfile
+++ b/packs/csharp/Jenkinsfile
@@ -41,12 +41,12 @@ pipeline {
             sh "git checkout master"
             // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
+            sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('jx-base') {
-              sh "jx step git credentials"
               sh "make tag"
             }
           }

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -45,16 +45,18 @@ pipeline {
           container('go') {
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME') {
               checkout scm
+
+              // ensure we're not on a detached head
+              sh "git checkout master"
+              // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
+              sh "git config --global credential.helper store"
+              sh "jx step validate --min-jx-version 1.1.73"
+              sh "jx step git credentials"
+
               // so we can retrieve the version in later steps
-              sh "echo \$(jx-release-version) > VERSION"
+              sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
             }
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME') {
-                // ensure we're not on a detached head
-                sh "git checkout master"
-                // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
-                sh "git config --global credential.helper store"
-                sh "jx step validate --min-jx-version 1.1.73"
-                sh "jx step git credentials"
 
                 sh "make tag"
             }

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
             // TODO
             //sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('nodejs') {

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {

--- a/packs/python/Jenkinsfile
+++ b/packs/python/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('python') {

--- a/packs/ruby/Jenkinsfile
+++ b/packs/ruby/Jenkinsfile
@@ -41,12 +41,13 @@ pipeline {
             sh "git checkout master"
             // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
+            sh "jx step git credentials"
+
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('ruby') {
-              sh "jx step git credentials"
               sh "make tag"
             }
           }

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('rust') {

--- a/packs/scala/Jenkinsfile
+++ b/packs/scala/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
+            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
             sh "echo versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {


### PR DESCRIPTION
Please reference https://github.com/jenkins-x/jx/issues/1180 for motivation. Allows jx-release-version to get the GitHub auth token from the credential store via the environmental variable. This is a hotfix and this credential system, in general, should be revised to handle secrets more securely.