### PR TITLE
The call to jx-release-version has to occur AFTER credentials have be…

### DIFF
--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -45,8 +45,6 @@ pipeline {
           container('go') {
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME') {
               checkout scm
-              // so we can retrieve the version in later steps
-              sh "echo \$(jx-release-version) > VERSION"
             }
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME') {
                 // ensure we're not on a detached head
@@ -55,8 +53,13 @@ pipeline {
                 sh "git config --global credential.helper store"
                 sh "jx step validate --min-jx-version 1.1.73"
                 sh "jx step git credentials"
-
-                sh "make tag"
+            }
+            dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME') {
+              // so we can retrieve the version in later steps
+              sh "echo \$(jx-release-version) > VERSION"
+            }
+            dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME') {
+              sh "make tag"
             }
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME') {
               container('go') {


### PR DESCRIPTION
…en created but BEFORE 'make tag' is called - so altering the order of these calls in the go draft pack.

@jstrachan 