### PR TITLE
Revert "Pass GITHUB_AUTH_TOKEN into jx-release-version"

### DIFF
--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {

--- a/packs/appserver/skaffold.yaml
+++ b/packs/appserver/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/csharp/Jenkinsfile
+++ b/packs/csharp/Jenkinsfile
@@ -41,12 +41,12 @@ pipeline {
             sh "git checkout master"
             // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
-            sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('jx-base') {
+              sh "jx step git credentials"
               sh "make tag"
             }
           }

--- a/packs/csharp/skaffold.yaml
+++ b/packs/csharp/skaffold.yaml
@@ -28,5 +28,5 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"
         

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -56,7 +56,7 @@ pipeline {
             }
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME') {
               // so we can retrieve the version in later steps
-              sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+              sh "echo \$(jx-release-version) > VERSION"
             }
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/REPLACE_ME_APP_NAME') {
               sh "make tag"

--- a/packs/go/skaffold.yaml
+++ b/packs/go/skaffold.yaml
@@ -28,5 +28,5 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"
         

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
             // TODO
             //sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }

--- a/packs/gradle/skaffold.yaml
+++ b/packs/gradle/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -48,7 +48,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('nodejs') {

--- a/packs/javascript/skaffold.yaml
+++ b/packs/javascript/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {

--- a/packs/liberty/skaffold.yaml
+++ b/packs/liberty/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
             sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {

--- a/packs/maven/skaffold.yaml
+++ b/packs/maven/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/php/skaffold.yaml
+++ b/packs/php/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/python/Jenkinsfile
+++ b/packs/python/Jenkinsfile
@@ -47,7 +47,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('python') {

--- a/packs/python/skaffold.yaml
+++ b/packs/python/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/ruby/Jenkinsfile
+++ b/packs/ruby/Jenkinsfile
@@ -41,13 +41,12 @@ pipeline {
             sh "git checkout master"
             // until we switch to the new kubernetes / jenkins credential implementation use git credentials store
             sh "git config --global credential.helper store"
-            sh "jx step git credentials"
-
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('ruby') {
+              sh "jx step git credentials"
               sh "make tag"
             }
           }

--- a/packs/ruby/skaffold.yaml
+++ b/packs/ruby/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -49,7 +49,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {
             container('rust') {

--- a/packs/rust/skaffold.yaml
+++ b/packs/rust/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/scala/Jenkinsfile
+++ b/packs/scala/Jenkinsfile
@@ -46,7 +46,7 @@ pipeline {
             sh "jx step validate --min-jx-version 1.1.73"
             sh "jx step git credentials"
             // so we can retrieve the version in later steps
-            sh "echo \$(GITHUB_AUTH_TOKEN=\$(echo  | git credential-store get | grep -o -P '(?<=password=).*'); jx-release-version) > VERSION"
+            sh "echo \$(jx-release-version) > VERSION"
             sh "echo versions:set -DnewVersion=\$(cat VERSION)"
           }
           dir ('./charts/REPLACE_ME_APP_NAME') {

--- a/packs/scala/skaffold.yaml
+++ b/packs/scala/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"

--- a/packs/swift/skaffold.yaml
+++ b/packs/swift/skaffold.yaml
@@ -28,4 +28,4 @@ profiles:
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
           image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
-          image.tag: "{{.DIGEST_HEX}}"
+          image.tag: "{{.TAG}}"


### PR DESCRIPTION
Reverts jenkins-x/draft-packs#45

Sorry - I'm going to need to revert this.  I think all that was needed was the jx-release-version has to happen after `sh "jx step git credentials"`.  Reverting and will merge the preferred way asap.