### PR TITLE
support exposing services using NodePort

### DIFF
--- a/packs/appserver/charts/templates/service.yaml
+++ b/packs/appserver/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/csharp/charts/templates/service.yaml
+++ b/packs/csharp/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/go/charts/templates/service.yaml
+++ b/packs/go/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/gradle/charts/templates/service.yaml
+++ b/packs/gradle/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/javascript/charts/templates/service.yaml
+++ b/packs/javascript/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/liberty/charts/templates/service.yaml
+++ b/packs/liberty/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/maven/charts/templates/service.yaml
+++ b/packs/maven/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/php/charts/templates/service.yaml
+++ b/packs/php/charts/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/python/charts/templates/service.yaml
+++ b/packs/python/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/ruby/charts/templates/service.yaml
+++ b/packs/ruby/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/rust/charts/templates/service.yaml
+++ b/packs/rust/charts/templates/service.yaml
@@ -17,6 +17,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:

--- a/packs/scala/charts/templates/service.yaml
+++ b/packs/scala/charts/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: {{ .Values.service.name }}
   selector:

--- a/packs/swift/chart/templates/service.yaml
+++ b/packs/swift/chart/templates/service.yaml
@@ -13,6 +13,9 @@ spec:
   ports:
   - port: {{ .Values.service.externalPort }}
     targetPort: {{ .Values.service.internalPort }}
+    {{- if (and (eq .Values.service.type "NodePort") (not (empty .Values.service.nodePort))) }}
+    nodePort: {{ .Values.service.nodePort }}
+    {{- end }}
     protocol: TCP
     name: http
   selector:


### PR DESCRIPTION
This adds an option to set the serviceType to NodePort and set the nodePort value. It is based on https://github.com/helm/charts/blob/f3e170ae27e47b4768585266823ad681488c690d/stable/rabbitmq/templates/svc.yaml#L19