### PR TITLE
added support for service labels in helm chart

### DIFF
--- a/packs/appserver/charts/templates/service.yaml
+++ b/packs/appserver/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/csharp/charts/templates/service.yaml
+++ b/packs/csharp/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/go/charts/templates/service.yaml
+++ b/packs/go/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/gradle/charts/templates/service.yaml
+++ b/packs/gradle/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/javascript/charts/templates/service.yaml
+++ b/packs/javascript/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/liberty/charts/templates/service.yaml
+++ b/packs/liberty/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/maven/charts/templates/service.yaml
+++ b/packs/maven/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/python/charts/templates/service.yaml
+++ b/packs/python/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/ruby/charts/templates/service.yaml
+++ b/packs/ruby/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/rust/charts/templates/service.yaml
+++ b/packs/rust/charts/templates/service.yaml
@@ -8,6 +8,9 @@ metadata:
 {{- end }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/packs/scala/charts/templates/service.yaml
+++ b/packs/scala/charts/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ template "fullname" . }}
   labels:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+{{- if .Values.service.labels }}
+{{ toYaml .Values.service.labels | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}


### PR DESCRIPTION
The reason for creating this PR was to add more flexibility in configuring Helm Charts.

Having the possibility to add labels to the Services seems to be very useful in many cases, for example in selecting Services for Prometheus monitoring by their label.

After applying this PR, extensions to the values.xml in quickstart projects will lead to the following chart:

values.xml
```
service:
  labels:
    system: my-system
    testLabel: test
```

Service:
```
apiVersion: v1
kind: Service
metadata:
  labels:
    chart: my-chart-0.0.7
    system: my-system
    testLabel: test
```