### PR TITLE
JVM memory settings from the memory limit of docker container

### DIFF
--- a/packs/appserver/Dockerfile
+++ b/packs/appserver/Dockerfile
@@ -3,4 +3,4 @@ ENV PORT 8080
 EXPOSE 8080
 COPY target/*.war /opt/app.war
 WORKDIR /opt
-CMD ["java", "-jar", "app.war"]
+CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "app.war"]

--- a/packs/gradle/Dockerfile
+++ b/packs/gradle/Dockerfile
@@ -3,4 +3,4 @@ ENV PORT 8080
 EXPOSE 8080
 COPY build/libs/*.jar /opt/app.jar
 WORKDIR /opt
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "app.jar"]

--- a/packs/maven/Dockerfile
+++ b/packs/maven/Dockerfile
@@ -11,4 +11,4 @@ COPY pom.xml target/lib* /opt/lib/
 # we could do with a better way to know the name - or to always create an app.jar or something
 COPY target/*.jar /opt/app.jar
 WORKDIR /opt
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "app.jar"]

--- a/packs/scala/Dockerfile
+++ b/packs/scala/Dockerfile
@@ -4,4 +4,4 @@ WORKDIR /opt/app
 COPY target/scala-*/*.jar /opt/app/app.jar
 # we could do with a better way to know the name - or to always create an app.jar or something
 WORKDIR /opt/app
-CMD ["java", "-jar", "app.jar"]
+CMD ["java", "-XX:+UnlockExperimentalVMOptions", "-XX:+UseCGroupMemoryLimitForHeap", "-jar", "app.jar"]


### PR DESCRIPTION
These changes are intended to remove the risk for experiencing out of memory kill on containers due to the jvm calculating higher memory limits that what are set on the container (via values.yaml). 

For background and details see https://blogs.oracle.com/java-platform-group/java-se-support-for-docker-cpu-and-memory-limits
In java 10 this will be the default behaviour