### PR TITLE
Use /health endpoint in Liberty values.yaml

### DIFF
--- a/packs/liberty/charts/values.yaml
+++ b/packs/liberty/charts/values.yaml
@@ -21,7 +21,7 @@ resources:
   requests:
     cpu: 400m
     memory: 512Mi
-probePath: /actuator/health
+probePath: /health
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 10


### PR DESCRIPTION
There is no right answer here (other than, perhaps, to have separate
packs and quick starts for Liberty Spring and Liberty MicroProfile applications)
but, for consistency with the MicroProfile application generated by the
current quick start, this should be using the MicroProfile health
endpoint of /health by default.