### PR TITLE
Add watch.sh for Liberty draft-pack

### DIFF
--- a/packs/liberty/charts/values.yaml
+++ b/packs/liberty/charts/values.yaml
@@ -21,7 +21,7 @@ resources:
   requests:
     cpu: 400m
     memory: 512Mi
-probePath: /actuator/health
+probePath: /health
 livenessProbe:
   initialDelaySeconds: 60
   periodSeconds: 10

--- a/packs/liberty/watch.sh
+++ b/packs/liberty/watch.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# watch the java files and continously deploy the service
+mvn clean install
+skaffold run -p dev
+reflex -r "\.java$" -- bash -c 'mvn install && skaffold run -p dev'


### PR DESCRIPTION
Adds a watch.sh file for the Liberty draft-pack so that applications can be easily deployed by just calling `watch.sh`. Also updates the health endpoint value since it was pointing to an incorrect endpoint and was causing the readiness probes to fail