### PR TITLE
Use docker registry repo instead of org

### DIFF
--- a/packs/D/Jenkinsfile
+++ b/packs/D/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
         label "jenkins-dlang"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -23,7 +24,7 @@ pipeline {
 
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -58,7 +59,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/D/charts/Makefile
+++ b/packs/D/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/D/preview/Makefile
+++ b/packs/D/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/D/skaffold.yaml
+++ b/packs/D/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.TAG}}"

--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
       label "jenkins-maven"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -24,7 +25,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -60,7 +61,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/appserver/charts/Makefile
+++ b/packs/appserver/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/appserver/preview/Makefile
+++ b/packs/appserver/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/appserver/skaffold.yaml
+++ b/packs/appserver/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/appserver/skaffold.yaml
+++ b/packs/appserver/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/csharp/Jenkinsfile
+++ b/packs/csharp/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
         label "jenkins-jx-base"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -19,8 +20,8 @@ pipeline {
         }
         steps {
           container('jx-base') {
-            sh "docker build -t $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-            sh "docker push $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "docker build -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION ."
+            sh "docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -51,8 +52,8 @@ pipeline {
             }
           }
           container('jx-base') {
-            sh "docker build -t $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION) ."
-            sh "docker push $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "docker build -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION) ."
+            sh "docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/csharp/charts/Makefile
+++ b/packs/csharp/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/csharp/skaffold.yaml
+++ b/packs/csharp/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -3,10 +3,11 @@ pipeline {
         label "jenkins-go"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      GIT_PROVIDER      = 'REPLACE_ME_GIT_PROVIDER'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      GIT_PROVIDER        = 'REPLACE_ME_GIT_PROVIDER'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -26,7 +27,7 @@ pipeline {
               sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
 
-              sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+              sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
             }
           }
           dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview') {
@@ -66,7 +67,7 @@ pipeline {
                 sh "make build"
                 sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-                sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+                sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
               }
             }
           }

--- a/packs/go/charts/Makefile
+++ b/packs/go/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/$(NAME)|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/$(NAME)|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to tag with"

--- a/packs/go/preview/Makefile
+++ b/packs/go/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/go/skaffold.yaml
+++ b/packs/go/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
       label "jenkins-gradle"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -24,7 +25,7 @@ pipeline {
             sh "gradle clean build"
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -61,7 +62,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/gradle/charts/Makefile
+++ b/packs/gradle/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/gradle/preview/Makefile
+++ b/packs/gradle/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/gradle/skaffold.yaml
+++ b/packs/gradle/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
         label "jenkins-nodejs"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -25,7 +26,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -61,7 +62,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/javascript/charts/Makefile
+++ b/packs/javascript/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/javascript/preview/Makefile
+++ b/packs/javascript/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/javascript/skaffold.yaml
+++ b/packs/javascript/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
       label "jenkins-maven"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -24,7 +25,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -60,7 +61,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/liberty/charts/Makefile
+++ b/packs/liberty/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/liberty/preview/Makefile
+++ b/packs/liberty/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/liberty/skaffold.yaml
+++ b/packs/liberty/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
       label "jenkins-maven"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -24,7 +25,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -61,7 +62,7 @@ pipeline {
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/maven/charts/Makefile
+++ b/packs/maven/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/maven/preview/Makefile
+++ b/packs/maven/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/maven/skaffold.yaml
+++ b/packs/maven/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/php/skaffold.yaml
+++ b/packs/php/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/python/Jenkinsfile
+++ b/packs/python/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
         label "jenkins-python"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -24,7 +25,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -59,7 +60,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/python/charts/Makefile
+++ b/packs/python/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/python/preview/Makefile
+++ b/packs/python/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/python/skaffold.yaml
+++ b/packs/python/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/ruby/Jenkinsfile
+++ b/packs/ruby/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
         label "jenkins-ruby"
     }
     environment {
-      ORG               = 'jenkinsx'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'jenkinsx'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -19,8 +20,8 @@ pipeline {
         }
         steps {
           container('ruby') {
-            sh "docker build -t $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-            sh "docker push $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "docker build -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION ."
+            sh "docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -51,8 +52,8 @@ pipeline {
             }
           }
           container('ruby') {
-            sh "docker build -t $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION) ."
-            sh "docker push $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "docker build -t $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION) ."
+            sh "docker push $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/ruby/charts/Makefile
+++ b/packs/ruby/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s/repository: .*/repository: $(DOCKER_REGISTRY)\/$(ORG)\/$(APP_NAME)/" values.yaml
+	sed -i -e "s/repository: .*/repository: $(DOCKER_REGISTRY)\/$(REPLACE_ME_DOCKER_REGISTRY_ORG)\/$(APP_NAME)/" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/ruby/charts/Makefile
+++ b/packs/ruby/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s/repository: .*/repository: $(DOCKER_REGISTRY)\/$(REPLACE_ME_DOCKER_REGISTRY_ORG)\/$(APP_NAME)/" values.yaml
+	sed -i -e "s/repository: .*/repository: $(DOCKER_REGISTRY)\/$(DOCKER_REGISTRY_ORG)\/$(APP_NAME)/" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/ruby/preview/Makefile
+++ b/packs/ruby/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/ruby/skaffold.yaml
+++ b/packs/ruby/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
         label "jenkins-rust"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -26,7 +27,7 @@ pipeline {
 
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -64,7 +65,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image $DOCKER_REGISTRY/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/rust/charts/Makefile
+++ b/packs/rust/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/rust/preview/Makefile
+++ b/packs/rust/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/rust/skaffold.yaml
+++ b/packs/rust/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/scala/Jenkinsfile
+++ b/packs/scala/Jenkinsfile
@@ -3,9 +3,10 @@ pipeline {
       label "jenkins-scala"
     }
     environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+      ORG                 = 'REPLACE_ME_ORG'
+      APP_NAME            = 'REPLACE_ME_APP_NAME'
+      CHARTMUSEUM_CREDS   = credentials('jenkins-x-chartmuseum')
+      DOCKER_REGISTRY_ORG = 'REPLACE_ME_DOCKER_REGISTRY_ORG'
     }
     stages {
       stage('CI Build and push snapshot') {
@@ -23,7 +24,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$DOCKER_REGISTRY_ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -60,7 +61,7 @@ pipeline {
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
 
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$DOCKER_REGISTRY_ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/scala/charts/Makefile
+++ b/packs/scala/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s/repository: .*/repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME/" values.yaml
+	sed -i -e "s/repository: .*/repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME/" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/scala/preview/Makefile
+++ b/packs/scala/preview/Makefile
@@ -8,7 +8,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_ORG\/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)\/REPLACE_ME_DOCKER_REGISTRY_ORG\/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/scala/skaffold.yaml
+++ b/packs/scala/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/swift/skaffold.yaml
+++ b/packs/swift/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_DOCKER_REGISTRY_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"


### PR DESCRIPTION
Tied to changes in [#1612 jenkins-x/jx](https://github.com/jenkins-x/jx/pull/1612).

As part of the above PR, the docker registry organisation can be specified when using the `jx import` command. In order for that to work the draft packs need to be updated with the new variable to set.

Merging into the `2.2` branch as these are breaking changes that rely on a version of `jx` higher than `1.3.237`