### PR TITLE
Disable concurrent builds on master

### DIFF
--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('maven') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/csharp/Jenkinsfile
+++ b/packs/csharp/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('jx-base') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -42,6 +42,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('go') {
             dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME') {
               checkout scm

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('gradle') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -41,6 +41,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('nodejs') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('maven') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('maven') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/python/Jenkinsfile
+++ b/packs/python/Jenkinsfile
@@ -40,6 +40,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('python') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/ruby/Jenkinsfile
+++ b/packs/ruby/Jenkinsfile
@@ -36,6 +36,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('ruby') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -42,6 +42,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('rust') {
             // ensure we're not on a detached head
             sh "git checkout master"

--- a/packs/scala/Jenkinsfile
+++ b/packs/scala/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
           branch 'master'
         }
         steps {
+          script{properties([disableConcurrentBuilds()])}
           container('scala') {
             // ensure we're not on a detached head
             sh "git checkout master"


### PR DESCRIPTION
When multiple jobs are triggered on master at the same time, they all try to create a new tag and create a new artifact with that tag version. In some cases they try to use the same tag and build fails when trying to deploy same version in Nexus. 

This solution will make sure one job finishes before starting another. PR builds are not an issue as PRs use unique version numbers instead of tag for versioning.