### PR TITLE
Use DOCKER_REGISTRY

### DIFF
--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -60,7 +60,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/appserver/charts/Makefile
+++ b/packs/appserver/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/appserver/preview/Makefile
+++ b/packs/appserver/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/appserver/skaffold.yaml
+++ b/packs/appserver/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/csharp/Jenkinsfile
+++ b/packs/csharp/Jenkinsfile
@@ -16,8 +16,8 @@ pipeline {
           HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
         }
         steps {
-          sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-          sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          sh "docker build -t \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION ."
+          sh "docker push \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
           dir ('./charts/preview') {
             sh "make preview"
@@ -39,8 +39,8 @@ pipeline {
             sh "jx step git credentials"
             sh "make tag"
           }
-          sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION) ."
-          sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+          sh "docker build -t \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION) ."
+          sh "docker push \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
         }
       }
       stage('Promote to Environments') {

--- a/packs/csharp/charts/Makefile
+++ b/packs/csharp/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/csharp/preview/Makefile
+++ b/packs/csharp/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/csharp/skaffold.yaml
+++ b/packs/csharp/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,6 +27,6 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"
         

--- a/packs/cwp/Jenkinsfile
+++ b/packs/cwp/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
           sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
           dir ('./charts/preview') {
             sh "make preview"
             sh "jx preview --app $APP_NAME --dir ../.."
@@ -49,7 +49,7 @@ pipeline {
           sh "make build"
           sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
         }
       }
       stage('Promote to Environments') {

--- a/packs/cwp/charts/Makefile
+++ b/packs/cwp/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/$(NAME)|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/$(NAME)|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to tag with"

--- a/packs/cwp/preview/Makefile
+++ b/packs/cwp/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/cwp/skaffold.yaml
+++ b/packs/cwp/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,6 +27,6 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"
         

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
           }
           dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview') {
             sh "make preview"
@@ -56,7 +56,7 @@ pipeline {
             sh "make build"
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/go/charts/Makefile
+++ b/packs/go/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/$(NAME)|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/$(NAME)|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to tag with"

--- a/packs/go/preview/Makefile
+++ b/packs/go/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/go/skaffold.yaml
+++ b/packs/go/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,6 +27,6 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"
         

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
           sh "gradle clean build"
           sh 'export VERSION=$PREVIEW_VERSION && skaffold run -f skaffold.yaml'
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
           dir ('./charts/preview') {
            sh "make preview"
@@ -49,7 +49,7 @@ pipeline {
 
           sh 'export VERSION=`cat VERSION` && skaffold run -f skaffold.yaml'
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
         }
       }
       stage('Promote to Environments') {

--- a/packs/gradle/charts/Makefile
+++ b/packs/gradle/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/gradle/preview/Makefile
+++ b/packs/gradle/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/gradle/skaffold.yaml
+++ b/packs/gradle/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
 
           dir ('./charts/preview') {
@@ -56,7 +56,7 @@ pipeline {
 
           sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
 
         }
       }

--- a/packs/javascript/charts/Makefile
+++ b/packs/javascript/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/javascript/preview/Makefile
+++ b/packs/javascript/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/javascript/skaffold.yaml
+++ b/packs/javascript/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/jenkins/Jenkinsfile
+++ b/packs/jenkins/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
           }
           dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview') {
             sh "make preview"
@@ -56,7 +56,7 @@ pipeline {
             sh "make build"
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/jenkins/charts/Makefile
+++ b/packs/jenkins/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/$(NAME)|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/$(NAME)|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to tag with"

--- a/packs/jenkins/preview/Makefile
+++ b/packs/jenkins/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/jenkins/skaffold.yaml
+++ b/packs/jenkins/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,6 +27,6 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"
         

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
             sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -60,7 +60,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
             sh "jx step validate --min-jx-version 1.2.36"
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/liberty/charts/Makefile
+++ b/packs/liberty/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/liberty/preview/Makefile
+++ b/packs/liberty/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/liberty/skaffold.yaml
+++ b/packs/liberty/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -22,7 +22,7 @@ pipeline {
           sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
 
           dir ('./charts/preview') {
@@ -56,7 +56,7 @@ pipeline {
 
             sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
-            sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
 
         }
       }

--- a/packs/maven/charts/Makefile
+++ b/packs/maven/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/maven/preview/Makefile
+++ b/packs/maven/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/maven/skaffold.yaml
+++ b/packs/maven/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/php/skaffold.yaml
+++ b/packs/php/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/python/Jenkinsfile
+++ b/packs/python/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
           sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
           dir ('./charts/preview') {
             sh "make preview"
@@ -47,7 +47,7 @@ pipeline {
 
           sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
         }
       }
       stage('Promote to Environments') {

--- a/packs/python/charts/Makefile
+++ b/packs/python/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/python/preview/Makefile
+++ b/packs/python/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/python/skaffold.yaml
+++ b/packs/python/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/ruby/Jenkinsfile
+++ b/packs/ruby/Jenkinsfile
@@ -19,8 +19,8 @@ pipeline {
         }
         steps {
           container('ruby') {
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+            sh "docker build -t \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION ."
+            sh "docker push \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
           }
 
           dir ('./charts/preview') {
@@ -51,8 +51,8 @@ pipeline {
             }
           }
           container('ruby') {
-            sh "docker build -t \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION) ."
-            sh "docker push \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+            sh "docker build -t \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION) ."
+            sh "docker push \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
           }
         }
       }

--- a/packs/ruby/charts/Makefile
+++ b/packs/ruby/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/$(ORG)/$(APP_NAME)|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/$(ORG)/$(APP_NAME)|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/ruby/preview/Makefile
+++ b/packs/ruby/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/ruby/skaffold.yaml
+++ b/packs/ruby/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -23,7 +23,7 @@ pipeline {
 
           sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
           dir ('./charts/preview') {
             sh "make preview"
@@ -52,7 +52,7 @@ pipeline {
 
           sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
         }
       }
       stage('Promote to Environments') {

--- a/packs/rust/charts/Makefile
+++ b/packs/rust/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/rust/preview/Makefile
+++ b/packs/rust/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/rust/skaffold.yaml
+++ b/packs/rust/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/scala/Jenkinsfile
+++ b/packs/scala/Jenkinsfile
@@ -20,7 +20,7 @@ pipeline {
           sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
 
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:$PREVIEW_VERSION"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
 
           dir ('./charts/preview') {
            sh "make preview"
@@ -48,7 +48,7 @@ pipeline {
           sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
 
           sh "jx step validate --min-jx-version 1.2.36"
-          sh "jx step post build --image \$JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST:\$JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT/$ORG/$APP_NAME:\$(cat VERSION)"
+          sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
         }
       }
       stage('Promote to Environments') {

--- a/packs/scala/charts/Makefile
+++ b/packs/scala/charts/Makefile
@@ -36,7 +36,7 @@ ifeq ($(OS),Darwin)
 	sed -i "" -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(RELEASE_VERSION)/" Chart.yaml
-	sed -i -e "s|repository: .*|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: .*|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(RELEASE_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/scala/preview/Makefile
+++ b/packs/scala/preview/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
 else ifeq ($(OS),Linux)
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" Chart.yaml
 	sed -i -e "s/version:.*/version: $(PREVIEW_VERSION)/" ../*/Chart.yaml
-	sed -i -e "s|repository: *|repository: $(JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST):$(JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
+	sed -i -e "s|repository: *|repository: $(DOCKER_REGISTRY)/REPLACE_ME_ORG/REPLACE_ME_APP_NAME|" values.yaml
 	sed -i -e "s/tag: .*/tag: $(PREVIEW_VERSION)/" values.yaml
 else
 	echo "platfrom $(OS) not supported to release from"

--- a/packs/scala/skaffold.yaml
+++ b/packs/scala/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"

--- a/packs/swift/skaffold.yaml
+++ b/packs/swift/skaffold.yaml
@@ -3,7 +3,7 @@ kind: Config
 build:
   tagPolicy:
     envTemplate:
-      template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
+      template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.VERSION}}"
   artifacts:
   - imageName: changeme
     workspace: .
@@ -17,7 +17,7 @@ profiles:
   build:
     tagPolicy:
       envTemplate:
-        template: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
+        template: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME:{{.DIGEST_HEX}}"
     artifacts:
     - docker: {}
     local: {}
@@ -27,5 +27,5 @@ profiles:
       - name: REPLACE_ME_APP_NAME
         chartPath: charts/REPLACE_ME_APP_NAME
         setValueTemplates:
-          image.repository: "{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST}}:{{.JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
+          image.repository: "{{.DOCKER_REGISTRY}}/REPLACE_ME_ORG/REPLACE_ME_APP_NAME"
           image.tag: "{{.DIGEST_HEX}}"


### PR DESCRIPTION
Replace use of `JENKINS_X_DOCKER_REGISTRY_SERVICE_HOST` and `JENKINS_X_DOCKER_REGISTRY_SERVICE_PORT` with `DOCKER_REGISTRY` to support platforms where an external registry is being used.

Resolves https://github.com/jenkins-x/jx/issues/2116