### PR TITLE
Always pass --batch-mode to jx preview from a Jenkinsfile

### DIFF
--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
           dir ('./charts/preview') {
            container('maven') {
              sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
+             sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
            }
           }
         }

--- a/packs/csharp/Jenkinsfile
+++ b/packs/csharp/Jenkinsfile
@@ -21,7 +21,7 @@ pipeline {
 
           dir ('./charts/preview') {
             sh "make preview"
-            sh "jx preview --app $APP_NAME --dir ../.."
+            sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }

--- a/packs/cwp/Jenkinsfile
+++ b/packs/cwp/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
           sh "jx step post build --image \$DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
           dir ('./charts/preview') {
             sh "make preview"
-            sh "jx preview --app $APP_NAME --dir ../.."
+            sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }

--- a/packs/go/Jenkinsfile
+++ b/packs/go/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
           }
           dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview') {
             sh "make preview"
-            sh "jx preview --app $APP_NAME --dir ../.."
+            sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }

--- a/packs/gradle/Jenkinsfile
+++ b/packs/gradle/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 
           dir ('./charts/preview') {
            sh "make preview"
-           sh "jx preview --app $APP_NAME --dir ../.."
+           sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }

--- a/packs/javascript/Jenkinsfile
+++ b/packs/javascript/Jenkinsfile
@@ -29,7 +29,7 @@ pipeline {
           dir ('./charts/preview') {
 
              sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
+             sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
 
           }
         }

--- a/packs/jenkins/Jenkinsfile
+++ b/packs/jenkins/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
           }
           dir ('/home/jenkins/go/src/REPLACE_ME_GIT_PROVIDER/REPLACE_ME_ORG/REPLACE_ME_APP_NAME/charts/preview') {
             sh "make preview"
-            sh "jx preview --app $APP_NAME --dir ../.."
+            sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -30,7 +30,7 @@ pipeline {
           dir ('./charts/preview') {
            container('maven') {
              sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
+             sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
            }
           }
         }

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -28,7 +28,7 @@ pipeline {
           dir ('./charts/preview') {
 
              sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
+             sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
 
           }
         }

--- a/packs/python/Jenkinsfile
+++ b/packs/python/Jenkinsfile
@@ -25,7 +25,7 @@ pipeline {
 
           dir ('./charts/preview') {
             sh "make preview"
-            sh "jx preview --app $APP_NAME --dir ../.."
+            sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }

--- a/packs/ruby/Jenkinsfile
+++ b/packs/ruby/Jenkinsfile
@@ -26,7 +26,7 @@ pipeline {
           dir ('./charts/preview') {
            container('ruby') {
              sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
+             sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
            }
           }
         }

--- a/packs/rust/Jenkinsfile
+++ b/packs/rust/Jenkinsfile
@@ -27,7 +27,7 @@ pipeline {
 
           dir ('./charts/preview') {
             sh "make preview"
-            sh "jx preview --app $APP_NAME --dir ../.."
+            sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }

--- a/packs/scala/Jenkinsfile
+++ b/packs/scala/Jenkinsfile
@@ -24,7 +24,7 @@ pipeline {
 
           dir ('./charts/preview') {
            sh "make preview"
-           sh "jx preview --app $APP_NAME --dir ../.."
+           sh "jx preview --batch-mode --app $APP_NAME --dir ../.."
           }
         }
       }


### PR DESCRIPTION
@pmuir says there was recently a fix for

    error: cannot create Git provider EOF

which is at least clearer when you are in the batch mode so you get

    error: cannot create Git provider Running in batch mode and no default Git username found

There is no reason for a `sh` step in a build to be waiting for input!