### PR TITLE
Build feature branches in Maven-based draft packs

### DIFF
--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -1,91 +1,108 @@
 pipeline {
-    agent {
-      label "jenkins-maven"
-    }
-    environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-    }
-    stages {
-      stage('CI Build and push snapshot') {
-        when {
-          branch 'PR-*'
-        }
-        environment {
-          PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
-          PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
-          HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
-        }
-        steps {
-          container('maven') {
-            sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
-            sh "mvn install"
-            sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
-
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
-          }
-
-          dir ('./charts/preview') {
-           container('maven') {
-             sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
-           }
-          }
-        }
-      }
-      stage('Build Release') {
-        when {
-          branch 'master'
-        }
-        steps {
-          container('maven') {
-            // ensure we're not on a detached head
-            sh "git checkout master"
-            sh "git config --global credential.helper store"
-
-            sh "jx step git credentials"
-            // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
-            sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
-          }
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh "make tag"
-            }
-          }
-          container('maven') {
-            sh 'mvn clean deploy'
-
-            sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
-          }
-        }
-      }
-      stage('Promote to Environments') {
-        when {
-          branch 'master'
-        }
-        steps {
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh 'jx step changelog --version v\$(cat ../../VERSION)'
-
-              // release the helm chart
-              sh 'jx step helm release'
-
-              // promote through all 'Auto' promotion Environments
-              sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+  agent {
+    label "jenkins-maven"
+  }
+  environment {
+    ORG               = 'REPLACE_ME_ORG'
+    APP_NAME          = 'REPLACE_ME_APP_NAME'
+    CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+  }
+  stages {
+    stage('Pre-Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              // ensure it is not on a detached head, and set the version
+              sh '''
+                git checkout master
+                echo \$(jx-release-version) > VERSION
+                mvn versions:set -DnewVersion=\$(cat VERSION)
+              '''
+            } else if (env.BRANCH_NAME.startsWith('PR-')) {
+              // set the version
+              sh "mvn versions:set -DnewVersion=0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
             }
           }
         }
       }
     }
-    post {
-        always {
-            cleanWs()
+    stage('Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              sh "mvn deploy"
+            } else {
+              sh "mvn install"
+            }
+          }
         }
+      }
+    }
+    stage('Preview') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+        PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
+        HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
+      }
+      steps {
+        container('maven') {
+          sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+        }
+        dir ('./charts/preview') {
+          container('maven') {
+            sh "make preview"
+            sh "jx preview --app $APP_NAME --dir ../.."
+          }
+        }
+      }
+    }
+    stage('Release') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('maven') {
+          sh "git config --global credential.helper store"
+          sh "jx step git credentials"
+        }
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh "make tag"
+          }
+        }
+        container('maven') {
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+        }
+      }
+    }
+    stage('Promote') {
+      when {
+        branch 'master'
+      }
+      steps {
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh 'jx step changelog --version v\$(cat ../../VERSION)'
+
+            // release the helm chart
+            sh 'jx step helm release'
+
+            // promote through all 'Auto' promotion Environments
+            sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+          }
+        }
+      }
     }
   }
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/packs/appserver/Jenkinsfile
+++ b/packs/appserver/Jenkinsfile
@@ -13,9 +13,11 @@ pipeline {
         container('maven') {
           script {
             if (env.BRANCH_NAME == 'master') {
-              // ensure it is not on a detached head, and set the version
+              // ensure it is not on a detached head, set up git credentials, and set the version
               sh '''
                 git checkout master
+                git config --global credential.helper store
+                jx step git credentials
                 echo \$(jx-release-version) > VERSION
                 mvn versions:set -DnewVersion=\$(cat VERSION)
               '''
@@ -67,10 +69,6 @@ pipeline {
         branch 'master'
       }
       steps {
-        container('maven') {
-          sh "git config --global credential.helper store"
-          sh "jx step git credentials"
-        }
         dir ('./charts/REPLACE_ME_APP_NAME') {
           container('maven') {
             sh "make tag"

--- a/packs/dropwizard/Jenkinsfile
+++ b/packs/dropwizard/Jenkinsfile
@@ -1,92 +1,108 @@
 pipeline {
-    agent {
-      label "jenkins-maven"
-    }
-    environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-    }
-    stages {
-      stage('CI Build and push snapshot') {
-        when {
-          branch 'PR-*'
-        }
-        environment {
-          PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
-          PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
-          HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
-        }
-        steps {
-          container('maven') {
-            sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
-            sh "mvn install"
-            sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
-
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
-          }
-
-          dir ('./charts/preview') {
-           container('maven') {
-             sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
-           }
-          }
-        }
-      }
-      stage('Build Release') {
-        when {
-          branch 'master'
-        }
-        steps {
-          container('maven') {
-            // ensure we're not on a detached head
-            sh "git checkout master"
-            sh "git config --global credential.helper store"
-
-            sh "jx step git credentials"
-            // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
-            sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
-          }
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh "make tag"
-            }
-          }
-          container('maven') {
-            sh 'mvn clean deploy'
-
-            sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
-
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
-          }
-        }
-      }
-      stage('Promote to Environments') {
-        when {
-          branch 'master'
-        }
-        steps {
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh 'jx step changelog --version v\$(cat ../../VERSION)'
-
-              // release the helm chart
-              sh 'jx step helm release'
-
-              // promote through all 'Auto' promotion Environments
-              sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+  agent {
+    label "jenkins-maven"
+  }
+  environment {
+    ORG               = 'REPLACE_ME_ORG'
+    APP_NAME          = 'REPLACE_ME_APP_NAME'
+    CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+  }
+  stages {
+    stage('Pre-Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              // ensure it is not on a detached head, and set the version
+              sh '''
+                git checkout master
+                echo \$(jx-release-version) > VERSION
+                mvn versions:set -DnewVersion=\$(cat VERSION)
+              '''
+            } else if (env.BRANCH_NAME.startsWith('PR-')) {
+              // set the version
+              sh "mvn versions:set -DnewVersion=0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
             }
           }
         }
       }
     }
-    post {
-        always {
-            cleanWs()
+    stage('Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              sh "mvn deploy"
+            } else {
+              sh "mvn install"
+            }
+          }
         }
+      }
+    }
+    stage('Preview') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+        PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
+        HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
+      }
+      steps {
+        container('maven') {
+          sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+        }
+        dir ('./charts/preview') {
+          container('maven') {
+            sh "make preview"
+            sh "jx preview --app $APP_NAME --dir ../.."
+          }
+        }
+      }
+    }
+    stage('Release') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('maven') {
+          sh "git config --global credential.helper store"
+          sh "jx step git credentials"
+        }
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh "make tag"
+          }
+        }
+        container('maven') {
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+        }
+      }
+    }
+    stage('Promote') {
+      when {
+        branch 'master'
+      }
+      steps {
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh 'jx step changelog --version v\$(cat ../../VERSION)'
+
+            // release the helm chart
+            sh 'jx step helm release'
+
+            // promote through all 'Auto' promotion Environments
+            sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+          }
+        }
+      }
     }
   }
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/packs/dropwizard/Jenkinsfile
+++ b/packs/dropwizard/Jenkinsfile
@@ -13,9 +13,11 @@ pipeline {
         container('maven') {
           script {
             if (env.BRANCH_NAME == 'master') {
-              // ensure it is not on a detached head, and set the version
+              // ensure it is not on a detached head, set up git credentials, and set the version
               sh '''
                 git checkout master
+                git config --global credential.helper store
+                jx step git credentials
                 echo \$(jx-release-version) > VERSION
                 mvn versions:set -DnewVersion=\$(cat VERSION)
               '''
@@ -67,10 +69,6 @@ pipeline {
         branch 'master'
       }
       steps {
-        container('maven') {
-          sh "git config --global credential.helper store"
-          sh "jx step git credentials"
-        }
         dir ('./charts/REPLACE_ME_APP_NAME') {
           container('maven') {
             sh "make tag"

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -1,91 +1,108 @@
 pipeline {
-    agent {
-      label "jenkins-maven"
-    }
-    environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-    }
-    stages {
-      stage('CI Build and push snapshot') {
-        when {
-          branch 'PR-*'
-        }
-        environment {
-          PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
-          PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
-          HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
-        }
-        steps {
-          container('maven') {
-            sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
-            sh "mvn install"
-            sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
-
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
-          }
-
-          dir ('./charts/preview') {
-           container('maven') {
-             sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
-           }
-          }
-        }
-      }
-      stage('Build Release') {
-        when {
-          branch 'master'
-        }
-        steps {
-          container('maven') {
-            // ensure we're not on a detached head
-            sh "git checkout master"
-            sh "git config --global credential.helper store"
-
-            sh "jx step git credentials"
-            // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
-            sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
-          }
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh "make tag"
-            }
-          }
-          container('maven') {
-            sh 'mvn clean deploy'
-
-            sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
-          }
-        }
-      }
-      stage('Promote to Environments') {
-        when {
-          branch 'master'
-        }
-        steps {
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh 'jx step changelog --version v\$(cat ../../VERSION)'
-
-              // release the helm chart
-              sh 'jx step helm release'
-
-              // promote through all 'Auto' promotion Environments
-              sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+  agent {
+    label "jenkins-maven"
+  }
+  environment {
+    ORG               = 'REPLACE_ME_ORG'
+    APP_NAME          = 'REPLACE_ME_APP_NAME'
+    CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+  }
+  stages {
+    stage('Pre-Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              // ensure it is not on a detached head, and set the version
+              sh '''
+                git checkout master
+                echo \$(jx-release-version) > VERSION
+                mvn versions:set -DnewVersion=\$(cat VERSION)
+              '''
+            } else if (env.BRANCH_NAME.startsWith('PR-')) {
+              // set the version
+              sh "mvn versions:set -DnewVersion=0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
             }
           }
         }
       }
     }
-    post {
-        always {
-            cleanWs()
+    stage('Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              sh "mvn deploy"
+            } else {
+              sh "mvn install"
+            }
+          }
         }
+      }
+    }
+    stage('Preview') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+        PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
+        HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
+      }
+      steps {
+        container('maven') {
+          sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+        }
+        dir ('./charts/preview') {
+          container('maven') {
+            sh "make preview"
+            sh "jx preview --app $APP_NAME --dir ../.."
+          }
+        }
+      }
+    }
+    stage('Release') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('maven') {
+          sh "git config --global credential.helper store"
+          sh "jx step git credentials"
+        }
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh "make tag"
+          }
+        }
+        container('maven') {
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+        }
+      }
+    }
+    stage('Promote') {
+      when {
+        branch 'master'
+      }
+      steps {
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh 'jx step changelog --version v\$(cat ../../VERSION)'
+
+            // release the helm chart
+            sh 'jx step helm release'
+
+            // promote through all 'Auto' promotion Environments
+            sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+          }
+        }
+      }
     }
   }
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/packs/liberty/Jenkinsfile
+++ b/packs/liberty/Jenkinsfile
@@ -13,9 +13,11 @@ pipeline {
         container('maven') {
           script {
             if (env.BRANCH_NAME == 'master') {
-              // ensure it is not on a detached head, and set the version
+              // ensure it is not on a detached head, set up git credentials, and set the version
               sh '''
                 git checkout master
+                git config --global credential.helper store
+                jx step git credentials
                 echo \$(jx-release-version) > VERSION
                 mvn versions:set -DnewVersion=\$(cat VERSION)
               '''
@@ -67,10 +69,6 @@ pipeline {
         branch 'master'
       }
       steps {
-        container('maven') {
-          sh "git config --global credential.helper store"
-          sh "jx step git credentials"
-        }
         dir ('./charts/REPLACE_ME_APP_NAME') {
           container('maven') {
             sh "make tag"

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -1,92 +1,108 @@
 pipeline {
-    agent {
-      label "jenkins-maven"
-    }
-    environment {
-      ORG               = 'REPLACE_ME_ORG'
-      APP_NAME          = 'REPLACE_ME_APP_NAME'
-      CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
-    }
-    stages {
-      stage('CI Build and push snapshot') {
-        when {
-          branch 'PR-*'
-        }
-        environment {
-          PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
-          PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
-          HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
-        }
-        steps {
-          container('maven') {
-            sh "mvn versions:set -DnewVersion=$PREVIEW_VERSION"
-            sh "mvn install"
-            sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
-
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
-          }
-
-          dir ('./charts/preview') {
-           container('maven') {
-             sh "make preview"
-             sh "jx preview --app $APP_NAME --dir ../.."
-           }
-          }
-        }
-      }
-      stage('Build Release') {
-        when {
-          branch 'master'
-        }
-        steps {
-          container('maven') {
-            // ensure we're not on a detached head
-            sh "git checkout master"
-            sh "git config --global credential.helper store"
-
-            sh "jx step git credentials"
-            // so we can retrieve the version in later steps
-            sh "echo \$(jx-release-version) > VERSION"
-            sh "mvn versions:set -DnewVersion=\$(cat VERSION)"
-          }
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh "make tag"
-            }
-          }
-          container('maven') {
-            sh 'mvn clean deploy'
-
-            sh 'export VERSION=`cat VERSION` && skaffold build -f skaffold.yaml'
-
-
-            sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
-          }
-        }
-      }
-      stage('Promote to Environments') {
-        when {
-          branch 'master'
-        }
-        steps {
-          dir ('./charts/REPLACE_ME_APP_NAME') {
-            container('maven') {
-              sh 'jx step changelog --version v\$(cat ../../VERSION)'
-
-              // release the helm chart
-              sh 'jx step helm release'
-
-              // promote through all 'Auto' promotion Environments
-              sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+  agent {
+    label "jenkins-maven"
+  }
+  environment {
+    ORG               = 'REPLACE_ME_ORG'
+    APP_NAME          = 'REPLACE_ME_APP_NAME'
+    CHARTMUSEUM_CREDS = credentials('jenkins-x-chartmuseum')
+  }
+  stages {
+    stage('Pre-Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              // ensure it is not on a detached head, and set the version
+              sh '''
+                git checkout master
+                echo \$(jx-release-version) > VERSION
+                mvn versions:set -DnewVersion=\$(cat VERSION)
+              '''
+            } else if (env.BRANCH_NAME.startsWith('PR-')) {
+              // set the version
+              sh "mvn versions:set -DnewVersion=0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
             }
           }
         }
       }
     }
-    post {
-        always {
-            cleanWs()
+    stage('Build') {
+      steps {
+        container('maven') {
+          script {
+            if (env.BRANCH_NAME == 'master') {
+              sh "mvn deploy"
+            } else {
+              sh "mvn install"
+            }
+          }
         }
+      }
+    }
+    stage('Preview') {
+      when {
+        branch 'PR-*'
+      }
+      environment {
+        PREVIEW_VERSION = "0.0.0-SNAPSHOT-$BRANCH_NAME-$BUILD_NUMBER"
+        PREVIEW_NAMESPACE = "$APP_NAME-$BRANCH_NAME".toLowerCase()
+        HELM_RELEASE = "$PREVIEW_NAMESPACE".toLowerCase()
+      }
+      steps {
+        container('maven') {
+          sh 'export VERSION=$PREVIEW_VERSION && skaffold build -f skaffold.yaml'
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:$PREVIEW_VERSION"
+        }
+        dir ('./charts/preview') {
+          container('maven') {
+            sh "make preview"
+            sh "jx preview --app $APP_NAME --dir ../.."
+          }
+        }
+      }
+    }
+    stage('Release') {
+      when {
+        branch 'master'
+      }
+      steps {
+        container('maven') {
+          sh "git config --global credential.helper store"
+          sh "jx step git credentials"
+        }
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh "make tag"
+          }
+        }
+        container('maven') {
+          sh "jx step post build --image $DOCKER_REGISTRY/$ORG/$APP_NAME:\$(cat VERSION)"
+        }
+      }
+    }
+    stage('Promote') {
+      when {
+        branch 'master'
+      }
+      steps {
+        dir ('./charts/REPLACE_ME_APP_NAME') {
+          container('maven') {
+            sh 'jx step changelog --version v\$(cat ../../VERSION)'
+
+            // release the helm chart
+            sh 'jx step helm release'
+
+            // promote through all 'Auto' promotion Environments
+            sh 'jx promote -b --all-auto --timeout 1h --version \$(cat ../../VERSION)'
+          }
+        }
+      }
     }
   }
+  post {
+    always {
+      cleanWs()
+    }
+  }
+}

--- a/packs/maven/Jenkinsfile
+++ b/packs/maven/Jenkinsfile
@@ -13,9 +13,11 @@ pipeline {
         container('maven') {
           script {
             if (env.BRANCH_NAME == 'master') {
-              // ensure it is not on a detached head, and set the version
+              // ensure it is not on a detached head, set up git credentials, and set the version
               sh '''
                 git checkout master
+                git config --global credential.helper store
+                jx step git credentials
                 echo \$(jx-release-version) > VERSION
                 mvn versions:set -DnewVersion=\$(cat VERSION)
               '''
@@ -67,10 +69,6 @@ pipeline {
         branch 'master'
       }
       steps {
-        container('maven') {
-          sh "git config --global credential.helper store"
-          sh "jx step git credentials"
-        }
         dir ('./charts/REPLACE_ME_APP_NAME') {
           container('maven') {
             sh "make tag"


### PR DESCRIPTION
This pull request is a request for feedback on how the Jenkinsfile has been restructured for Maven-based draft packs. I recognize that there is a desire to move to prow commands, and that there are a lot of opinions on how to structure a build pipeline, and so this PR may not go anywhere.

The previous pipeline flow used stages to control conditional execution of steps. For example, a build stage existed for PR branches, and another build stage existed for master. Here is an example (note that an Acceptance Tests stage was added when I was experimenting with it):

![image](https://user-images.githubusercontent.com/5344425/48646892-6e0dab80-e9a7-11e8-9f3e-267800d80853.png)

Feature branches were not being built using the Jenkinsfile, which was fixed; in addition to building all branches, the file was re-worked so that each stage feeds into the next stage like a pipeline, where all branches go through a pre-build stage, then a build stage, etc. The conditional execution is controlled within the stage.

![image](https://user-images.githubusercontent.com/5344425/48647231-9f3aab80-e9a8-11e8-9a1c-3cf1ddb5033d.png)

